### PR TITLE
take into account collectionFormat in validation (issue #4)

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -17,6 +17,20 @@ parameters = yaml.load("""
   type: array
   items:
     type: integer
+- name: road_id_csv
+  in: query
+  required: true
+  type: array
+  collectionFormat: csv
+  items:
+    type: integer
+- name: road_id_brackets
+  in: query
+  required: true
+  type: array
+  collectionFormat: brackets
+  items:
+    type: integer
 - name: gt
   in: path
   required: false
@@ -53,11 +67,16 @@ def test_route():
         'GET', handler=handler, resource=None,
         swagger_data=sd)
     r.build_swagger_data({})
-    request = make_mocked_request('GET', '/?road_id=1&road_id=2')
+    query = ('/?road_id=1&road_id=2'
+             '&road_id_csv=1,2'
+             '&road_id_brackets[]=1&road_id_brackets[]=2')
+    request = make_mocked_request('GET', query)
     request._match_info = {}
     resp = yield from r.handler(request)
     assert isinstance(resp, dict), resp
     assert 'road_id' in resp, resp
+    assert 'road_id_csv' in resp, resp
+    assert 'road_id_brackets' in resp, resp
 
 
 @asyncio.coroutine
@@ -111,10 +130,13 @@ def test_router(test_client):
         return app
 
     cli = yield from test_client(factory)
-    resp = yield from cli.post('/?road_id=1')
+    query = '/?road_id=1&road_id_csv=1&road_id_brackets[]=1'
+    resp = yield from cli.post(query)
     assert resp.status == 200, resp
     txt = yield from resp.text()
     assert 'road_id' in txt, txt
+    assert 'road_id_csv' in txt, txt
+    assert 'road_id_brackets' in txt, txt
 
 
 @asyncio.coroutine


### PR DESCRIPTION
issue #4 

The swagger specification allows to specify how array parameters are
formatted:

  collectionFormat determines the format of the array if type array is
  used. Possible values are:

    csv - comma separated values foo,bar.
    ssv - space separated values foo bar.
    tsv - tab separated values foo\tbar.
    pipes - pipe separated values foo|bar.
    multi - corresponds to multiple parameter instances instead of
      multiple values for a single instance foo=bar&foo=baz. This is
      valid only for parameters in "query" or "formData".

Previously, only the "multi" format was allowed. This patch introduces
the support for other formats.

Note1: for backward compatibility, the default format is "multi" even
       if the specification says "Default value is csv".

Note2: This patch also adds support for the "brackets" format because
       as used by swagger-js
       (https://github.com/swagger-api/swagger-js/blob/master/lib/types/operation.js#L1149)