### PR TITLE
Take into account the default value for array parameters

### DIFF
--- a/aiohttp_apiset/swagger/route.py
+++ b/aiohttp_apiset/swagger/route.py
@@ -131,7 +131,9 @@ class SwaggerRoute(Route):
 
             if is_array and hasattr(source, 'getall'):
                 collection_format = param.get('collectionFormat')
-                value = get_collection(source, name, collection_format)
+                default = param.get('default', [])
+                value = get_collection(source, name,
+                                       collection_format, default)
             elif isinstance(source, Mapping) and name in source \
                     and (vtype not in ('number', 'integer') or
                          source[name] != ''):

--- a/aiohttp_apiset/swagger/validate.py
+++ b/aiohttp_apiset/swagger/validate.py
@@ -66,7 +66,7 @@ def validator(schema):
 COLLECTION_SEP = {'csv': ',', 'ssv': ' ', 'tsv': '\t', 'pipes': '|'}
 
 
-def get_collection(source, name, collection_format):
+def get_collection(source, name, collection_format, default):
     """get collection named `name` from the given `source` that
     formatted accordingly to `collection_format`.
     """
@@ -74,7 +74,7 @@ def get_collection(source, name, collection_format):
         separator = COLLECTION_SEP[collection_format]
         value = source.get(name, None)
         if value is None:
-            return []
+            return default
         return value.split(separator)
     if collection_format == 'brackets':
         return source.getall(name + '[]', [])

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -40,6 +40,14 @@ parameters = yaml.load("""
   collectionFormat: brackets
   items:
     type: integer
+- name: road_id_default
+  in: query
+  required: true
+  type: array
+  collectionFormat: csv
+  default: [42]
+  items:
+    type: integer
 - name: gt
   in: path
   required: false
@@ -88,6 +96,7 @@ def test_route():
     assert resp.get('road_id_csv') == [1, 2], resp
     assert resp.get('road_id_ssv') == [1, 2], resp
     assert resp.get('road_id_brackets') == [1, 2], resp
+    assert resp.get('road_id_default') == [42], resp
 
 
 @asyncio.coroutine


### PR DESCRIPTION
The validation skipped the `default` value when the parameter type
was an array.

Note: as defined in the specification, the default value must conform
to the defined type of the parameter.